### PR TITLE
Resolve `pwd - ModuleNotFoundError` on Windows

### DIFF
--- a/chs/ui/board.py
+++ b/chs/ui/board.py
@@ -1,5 +1,5 @@
 import chess
-import pwd
+import getpass
 import os
 
 from chs.client.ending import GameOver
@@ -183,7 +183,7 @@ class Board(object):
 
   def get_user(self, is_computer=False):
     title = '{}BOT {}'.format(Colors.ORANGE, Colors.RESET) if is_computer else ''
-    name = 'stockfish {}'.format(self._level) if is_computer else pwd.getpwuid(os.getuid()).pw_name
+    name = 'stockfish {}'.format(self._level) if is_computer else getpass.getuser()
     return '{}● {}{}{}{}'.format(Colors.DULL_GREEN, title, Colors.LIGHT, name, Colors.RESET)
 
   def get_bar_section(self, rank):


### PR DESCRIPTION
The `pwd` module used to get the username for display is Unix specific. Therefore, on Windows when attempting to import `pwd` the error `ModuleNotFoundError: No module named pwd` comes up and the program terminates. Utilizing the [getpass](https://docs.python.org/3/library/getpass.html#getpass.getuser) module is the portable solution.

I have tested this implementation on Windows 10, Mac, and Debian.

Resolves #10 