### PR TITLE
Mentioning AUR package in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,20 @@
 
 ## Installation
 
+### Pip
+
 This package is available via PyPi.
 
 ```
 $ python3 -m pip install chs
+```
+
+### Arch Linux
+
+There is a [chs-git](https://aur.archlinux.org/packages/chs-git/) package in the Arch User Repository, which you can install with an AUR helper:
+
+```
+$ yay -S chs-git || paru -S chs-git
 ```
 
 ## Usage


### PR DESCRIPTION
Hi, I've packaged `chs` in the Arch User Repository, pulling directly from the latest master (mostly because of #13, would make a stable release otherwise). 